### PR TITLE
fix soma bounding box for 2D plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ The development of this software was supported by funding to the Blue Brain Proj
 For license and authors, see `LICENSE.txt` and `AUTHORS.md` respectively.
 
 Copyright (c) 2015-2022 Blue Brain Project/EPFL
+Copyright (c) 2025- Open Brain Institute

--- a/neurom/view/matplotlib_impl.py
+++ b/neurom/view/matplotlib_impl.py
@@ -43,7 +43,12 @@ from neurom.core.soma import SomaCylinders
 from neurom.core.types import tree_type_checker
 from neurom.morphmath import segment_radius
 from neurom.view import matplotlib_utils
-from neurom.view.dendrogram import Dendrogram, get_size, layout_dendrogram, move_positions
+from neurom.view.dendrogram import (
+    Dendrogram,
+    get_size,
+    layout_dendrogram,
+    move_positions,
+)
 
 _LINEWIDTH = 1.2
 _ALPHA = 0.8
@@ -219,10 +224,22 @@ def plot_soma(
                 color=color,
                 alpha=alpha,
             )
+        radii = soma.points[:, COLS.R]
+        datalim = np.array(
+            [
+                [np.min(soma.points[:, plane0] - radii), np.min(soma.points[:, plane1] - radii)],
+                [np.max(soma.points[:, plane0] + radii), np.max(soma.points[:, plane1] + radii)],
+            ]
+        )
     else:
         if soma_outline:
             ax.add_artist(
                 Circle(soma.center[[plane0, plane1]], soma.radius, color=color, alpha=alpha)
+            )
+            center = soma.center
+            r = soma.radius
+            datalim = np.array(
+                [[center[plane0] - r, center[plane1] - r], [center[plane0] + r, center[plane1] + r]]
             )
         else:
             points = [[p[plane0], p[plane1]] for p in soma.iter()]
@@ -230,20 +247,17 @@ def plot_soma(
                 points.append(points[0])  # close the loop
                 x, y = tuple(np.array(points).T)
                 ax.plot(x, y, color=color, alpha=alpha, linewidth=linewidth)
+            bounding_box = geom.bounding_box(soma)
+            datalim = np.array(
+                [
+                    [bounding_box[0][plane0], bounding_box[0][plane1]],
+                    [bounding_box[1][plane0], bounding_box[1][plane1]],
+                ]
+            )
 
     ax.set_xlabel(plane[0])
     ax.set_ylabel(plane[1])
-
-    bounding_box = geom.bounding_box(soma)
-    ax.dataLim.update_from_data_xy(
-        np.vstack(
-            (
-                [bounding_box[0][plane0], bounding_box[0][plane1]],
-                [bounding_box[1][plane0], bounding_box[1][plane1]],
-            )
-        ),
-        ignore=False,
-    )
+    ax.update_datalim(datalim)
 
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
This morphology: 
[morph.txt](https://github.com/user-attachments/files/25416696/morph.txt)

was displayed with a truncated soma,
<img width="428" height="250" alt="image" src="https://github.com/user-attachments/assets/e2925326-6624-4237-a170-85bc8d7d5518" />



 with the following code:

`fig, ax = matplotlib_utils.get_figure()

matplotlib_impl.plot_morph(m, ax)

ax.set_title("")
ax.set_aspect("equal")
ax.set_frame_on(False)
ax.xaxis.set_visible(False)
ax.yaxis.set_visible(False)
bounds = ax.dataLim.bounds
print(bounds)
white_space = 0.05
ax.set_xlim(bounds[0] - white_space, bounds[0] + bounds[2] + white_space)
ax.set_ylim(bounds[1] - white_space, bounds[1] + bounds[3] + white_space)

fig.set_layout_engine("tight")`

Now it is displayed properly:
<img width="767" height="379" alt="image" src="https://github.com/user-attachments/assets/deadae91-e0f8-4d4b-82e9-4f8a59488aed" />
